### PR TITLE
added kernel ridge regression

### DIFF
--- a/gzip_regressor.py
+++ b/gzip_regressor.py
@@ -5,7 +5,8 @@ from collections import Counter
 from functools import partial
 import numpy as np
 from tqdm import tqdm
-
+from scipy.linalg import solve
+from sklearn.metrics.pairwise import pairwise_distances
 
 def regress_(x1, X_train, y_train, k):
     Cx1 = len(gzip.compress(x1.encode()))
@@ -47,3 +48,44 @@ def regress(X_train, y_train, X_test, k):
         )
 
     return np.array(preds)
+
+
+def compute_pairwise_ncd(pair):
+    x1, x2 = pair
+    Cx1 = len(gzip.compress(x1.encode()))
+    Cx2 = len(gzip.compress(x2.encode()))
+    Cx1x2 = len(gzip.compress(" ".join([x1, x2]).encode()))
+    ncd = (Cx1x2 - min(Cx1, Cx2)) / max(Cx1, Cx2)
+    return ncd
+
+def compute_ncd(X1, X2):
+    pairs = [(x1, x2) for x1 in X1 for x2 in X2]
+    with multiprocessing.Pool() as pool:
+        ncd_values = pool.map(compute_pairwise_ncd, pairs)
+    NCD = np.array(ncd_values).reshape(len(X1), len(X2))
+    return NCD
+
+
+def train_kernel_ridge_regression(X_train, y_train, gamma, lambda_):
+    # Compute the pairwise distance matrix
+    NCD = compute_ncd(X_train, X_train)
+    
+    # Compute the Laplacian kernel matrix
+    K = np.exp(-gamma * NCD)
+    
+    # Solve for alpha
+    alpha = solve(K + lambda_ * np.eye(K.shape[0]), y_train)
+    
+    return alpha
+
+def predict_kernel_ridge_regression(X_train, X_test, alpha, gamma):
+    # Compute the pairwise distance matrix between X_test and X_train
+    NCD_test = compute_ncd(X_test, X_train)
+    
+    # Compute the Laplacian kernel matrix
+    K_test = np.exp(-gamma * NCD_test)
+    
+    # Compute the predictions
+    y_pred = K_test.dot(alpha)
+    
+    return y_pred


### PR DESCRIPTION
added functions for kernel ridge regression with Laplacian kernel 
in `gzip_regressor.py`

`compute_pairwise_ncd` 
computed normalized compression density

`compute_ncd` 
enter multiprocessing

`train_kernel_ridge_regression`
it trains...

`predict_kernel_ridge_regression1`
well it predicts...


For the datasets provided seems to perform about as well as KNN but I did not yet carefully try different hyperparameters. 

Planing to test this for larger datasets such as QM9 as well as other types of molecular representations (e.g. binned numerical representations, or simply rdkit fingerprint, instead of string based representations). For the datasets benchmark here I expect Rdkit FP to be decent!